### PR TITLE
Adding Glove and Tensorflow compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,16 +87,25 @@ word2<tab>tag1<tab>emb=val1,val2,val3,...
 
 Note that the dimensions of embeddings should match the `--embeds_in_file_dim` option.
 
-We also provide scripts to generate these files for four commonly used embeddings types (Polyglot, Fasttext, ELMo and BERT), which can be found in the `embeds` folder. If we for example want to use BERT embeddings we need to run the following commands:
+We also provide scripts to generate these files for four commonly used embeddings types (Polyglot, Fasttext, Glove, ELMo and BERT), which can be found in the `embeds` folder. If we for example want to use BERT embeddings we need to run the following commands:
 
 ```
-python3 embeds/transf.py bert-base-multilingual-cased data/da-ud-train.conllu
-python3 embeds/transf.py bert-base-multilingual-cased data/da-ud-dev.conllu
-python3 embeds/transf.py bert-base-multilingual-cased data/da-ud-test.conllu
-
+python3 embeds/transf.py data/da-ud-train.conllu bert-base-multilingual-cased
+python3 embeds/transf.py data/da-ud-dev.conllu bert-base-multilingual-cased
+python3 embeds/transf.py data/da-ud-test.conllu bert-base-multilingual-cased
 ``` 
 
 This creates .bert files which can be used as input to Bilty when `--embeds_in_file` is enabled. 
+
+Similarly you can use one of your own pretrained transformer models in a tensorflow format using the following commands:
+
+```
+python3 embeds/transf.py data/da-ud-train.conllu embeds/bert.ckpt-xxxx.index embeds/vocab.txt embeds/bert_config.json
+python3 embeds/transf.py data/da-ud-dev.conllu embeds/bert.ckpt-xxxx.index embeds/vocab.txt embeds/bert_config.json
+python3 embeds/transf.py data/da-ud-test.conllu embeds/bert.ckpt-xxxx.index embeds/vocab.txt embeds/bert_config.json
+```
+
+If the folder containing the `.index` and the vocab contains a file named `config.json` you can leave out the last argument in the above commands.
 
 Similar scripts for Poly are in the `embeds` folder. For now the language for most of these is hardcoded in the scripts, please modify `*.prep.py` accordingly.
 

--- a/embeds/glove.py
+++ b/embeds/glove.py
@@ -1,0 +1,26 @@
+import sys
+from embeddings import GloveEmbedding
+
+if len(sys.argv) < 3:
+    print("please provide embeddings and pos conl file")
+    exit(0)
+
+
+embs = GloveEmbedding(sys.argv[1], default="random")
+
+unk = "<UNK>"
+
+outFile = open(sys.argv[2] + ".glove", "w")
+curSent = ""
+for line in open(sys.argv[2]):
+    if len(line) < 2:
+        outFile.write(curSent + "\n")
+        curSent = ""
+    else:
+        tok = line.strip().split("\t")
+        emb = embs.emb(tok[0])
+
+        embStr = "emb=" + ",".join([str(x) for x in emb])
+        curSent += "\t".join(tok + [embStr]) + "\n"
+
+outFile.close()

--- a/embeds/transf.py
+++ b/embeds/transf.py
@@ -1,57 +1,72 @@
 # This script is built for transformers 4.0.0, it needs adaptations for older versions
 
-#based on https://github.com/huggingface/transformers/blob/master/notebooks/02-transformers.ipynb
-#TODO could probably be faster when batching is used?
-#TODO apparently running on gpu is trivial? (https://github.com/huggingface/transformers/issues/2704)
+# based on https://github.com/huggingface/transformers/blob/master/notebooks/02-transformers.ipynb
+# TODO could probably be faster when batching is used?
+# TODO apparently running on gpu is trivial? (https://github.com/huggingface/transformers/issues/2704)
 
-import torch
 import sys
 from transformers import AutoModel, AutoTokenizer
 
 if len(sys.argv) < 3:
-    print('please provide embeddings name (from https://huggingface.co/models) and pos conll file')
+    print(
+        "please provide embeddings name (from https://huggingface.co/models) and pos conll file"
+    )
     exit(0)
+elif len(sys.argv) == 3:
+    # python transf.py CONLL_FILE TRANSFORMER_NAME
+    model = AutoModel.from_pretrained(sys.argv[2])
+    tokenizer = AutoTokenizer.from_pretrained(sys.argv[2])
+elif len(sys.argv) == 4:
+    # python transf.py CONLL_FILE TRANSFORMER_INDEX TRANSFORMER_VOCAB
+    model = AutoModel.from_pretrained(sys.argv[2])
+    tokenizer = AutoTokenizer.from_pretrained(sys.argv[3])
+elif len(sys.argv) == 5:
+    # python transf.py CONLL_FILE TRANSFORMER_INDEX TRANSFORMER_VOCAB TRANSFORMER_CONFIG
+    from transformers import AutoConfig
 
-model = AutoModel.from_pretrained(sys.argv[1])
-tokenizer = AutoTokenizer.from_pretrained(sys.argv[1])
+    config = AutoConfig.from_pretrained(sys.argv[4])
+    model = AutoModel.from_pretrained(sys.argv[2], config=config)
+    tokenizer = AutoTokenizer.from_pretrained(sys.argv[3])
+else:
+    print("Too many arguments, can't make sense of this.")
+    exit(0)
 
 
 def sentToEmbed(sent):
-    tokens_pt = tokenizer(sent, return_tensors="pt", return_offsets_mapping=True, is_split_into_words=True)
+    tokens_pt = tokenizer(
+        sent, return_tensors="pt", return_offsets_mapping=True, is_split_into_words=True
+    )
 
     # first dimension=first sent. Second dimensions = remove special tokens
-    offsets = tokens_pt['offset_mapping'][0][1:-1] 
-    
+    offsets = tokens_pt["offset_mapping"][0][1:-1]
+
     # first dimension, get full output (not pool) second dimension, get first sentence, third dimension remove special tokens
-    outputs = model(tokens_pt['input_ids'])[0][0][1:-1]
+    outputs = model(tokens_pt["input_ids"])[0][0][1:-1]
     # size of outputs is now the number of wordpieces without special tokens, 2nd dimensions is embeddings size
-    
+
     # get all indexes that should be kept
     startOfWords = []
     for offsetIdx, offset in enumerate(offsets):
         if offset[0] == 0:
             startOfWords.append(offsetIdx)
-    
+
     # keep only the first embedding of each word
     return outputs[startOfWords, :]
 
 
-
-outFile = open(sys.argv[2] + '.' + sys.argv[1], 'w')
+outFile = open(sys.argv[1] + "." + sys.argv[2], "w")
 curSent = []
-for line in open(sys.argv[2]):
-    line=line.strip('\n')
+for line in open(sys.argv[1]):
+    line = line.strip("\n")
     if len(line) < 2:
         embeds = sentToEmbed([word[0] for word in curSent])
         for word, embed in zip(curSent, embeds):
-            embStr = 'emb=' + ','.join([str(float(x)) for x in embed])
-            outFile.write('\t'.join(word + [embStr]) + '\n')
-        outFile.write('\n')
+            embStr = "emb=" + ",".join([str(float(x)) for x in embed])
+            outFile.write("\t".join(word + [embStr]) + "\n")
+        outFile.write("\n")
         curSent = []
     else:
-        tok = line.strip().split('\t')
+        tok = line.strip().split("\t")
         curSent.append(tok)
 
 outFile.close()
-
-

--- a/embeds/transf.py
+++ b/embeds/transf.py
@@ -18,14 +18,14 @@ elif len(sys.argv) == 3:
     tokenizer = AutoTokenizer.from_pretrained(sys.argv[2])
 elif len(sys.argv) == 4:
     # python transf.py CONLL_FILE TRANSFORMER_INDEX TRANSFORMER_VOCAB
-    model = AutoModel.from_pretrained(sys.argv[2])
+    model = AutoModel.from_pretrained(sys.argv[2], from_tf=True)
     tokenizer = AutoTokenizer.from_pretrained(sys.argv[3])
 elif len(sys.argv) == 5:
     # python transf.py CONLL_FILE TRANSFORMER_INDEX TRANSFORMER_VOCAB TRANSFORMER_CONFIG
     from transformers import AutoConfig
 
     config = AutoConfig.from_pretrained(sys.argv[4])
-    model = AutoModel.from_pretrained(sys.argv[2], config=config)
+    model = AutoModel.from_pretrained(sys.argv[2], config=config, from_tf=True)
     tokenizer = AutoTokenizer.from_pretrained(sys.argv[3])
 else:
     print("Too many arguments, can't make sense of this.")


### PR DESCRIPTION
I added **two** things to the embeds folder:

1. Glove compatibility
2. Made it possible to open a local pre-trained transformer

### Glove Compatibility
Following the format of `poly.py`, we can now load different versions of the Glove embeddings and add them to the CONLL files.  It uses the [embeddings](https://pypi.org/project/embeddings/) library to load the Glove embeddings. You can get all four kinds of embeddings using one of these tags:

- common_crawl_48
- common_crawl_840
- twitter
- wikipedia_gigaword

### Local Transformer
Using the huggingface transformers library we are also able to open custom transformers we have saved locally. These should be in the TensorFlow checkpoint format. In regards to this, I also updated the readme to show users how to do this, since this can be a little tricky. 

> Similarly you can use one of your own pretrained transformer models in a tensorflow format using the following commands:
>
>```
>python3 embeds/transf.py data/da-ud-train.conllu embeds/bert.ckpt-xxxx.index embeds/vocab.txt >embeds/bert_config.json
>python3 embeds/transf.py data/da-ud-dev.conllu embeds/bert.ckpt-xxxx.index embeds/vocab.txt embeds/bert_config.json
>python3 embeds/transf.py data/da-ud-test.conllu embeds/bert.ckpt-xxxx.index embeds/vocab.txt embeds/bert_config.json
>```
>
>If the folder containing the `.index` and the vocab contains a file named `config.json` you can leave out the last argument in the above commands.

